### PR TITLE
수정 Tree에서 아이템 더블 클릭시 이미지 뷰어 화면 갱신

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -25,11 +25,11 @@ namespace ExtremeEnviroment
         public MainWindow()
         {
             InitializeComponent();
-            //InitLayout();
         }
 
-        private void InitLayout()
+        internal ImageViewControl GetImageViewControl()
         {
+            return this.ImageViewer;
         }
     }
 }

--- a/Module/ImageList/ImageListControl.xaml
+++ b/Module/ImageList/ImageListControl.xaml
@@ -17,8 +17,8 @@
             </TreeView>
         </GroupBox>
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" MinHeight="25">
-            <Button x:Name="btnAddItem" Width="50" Margin="10 2 0 2" Content="+" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Click="btnAddItem_Click"></Button>
-            <Button x:Name="btnRemoveItem" Width="50" Margin="5 2 0 2" Content="-" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Click="btnRemoveItem_Click"></Button>
+            <Button x:Name="btnAddItem" Width="50" Margin="10 2 0 2" Content="+" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Click="BtnAddItem_Click"></Button>
+            <Button x:Name="btnRemoveItem" Width="50" Margin="5 2 0 2" Content="-" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Click="BtnRemoveItem_Click"></Button>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/Module/ImageList/ImageListControl.xaml.cs
+++ b/Module/ImageList/ImageListControl.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using Path = System.IO.Path;
+using ExtremeEnviroment.Module.ImageView;
 
 namespace ExtremeEnviroment.Module.ImageList
 {
@@ -136,11 +137,13 @@ namespace ExtremeEnviroment.Module.ImageList
         private void OnTreeViewItemDoubleClick(object sender, RoutedEventArgs e)
         {
             BitmapImage bitmapImage = this.SelectedItemImage;
-            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(bitmapImage.UriSource.AbsolutePath);
+            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+            ImageViewControl imageViewControl = mainWindow.GetImageViewControl();
+            imageViewControl.SetImageSource(bitmapImage);
         }
 
         // Add Button Handler
-        private void btnAddItem_Click(object sender, RoutedEventArgs e)
+        private void BtnAddItem_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog openFileDialog = new OpenFileDialog()
             {
@@ -159,7 +162,7 @@ namespace ExtremeEnviroment.Module.ImageList
             }
         }
         // Remove Button Handler
-        private void btnRemoveItem_Click(object sender, RoutedEventArgs e)
+        private void BtnRemoveItem_Click(object sender, RoutedEventArgs e)
         {
             if (this.SelectedItem != null)
             {

--- a/Module/ImageList/ImageListControl.xaml.cs
+++ b/Module/ImageList/ImageListControl.xaml.cs
@@ -60,8 +60,8 @@ namespace ExtremeEnviroment.Module.ImageList
             {
                 BitmapImage imageSource = null;
                 TreeViewItem selectedItem = this.SelectedItem;
-
-                if (selectedItem != null)
+                
+                if (selectedItem != null && selectedItem.Header is TextBlock)
                 {
                     TextBlock textBlock = (TextBlock)selectedItem.Header;
                     Image thumnailImage = (Image)((InlineUIContainer)textBlock.Inlines.FirstInline).Child;
@@ -137,9 +137,13 @@ namespace ExtremeEnviroment.Module.ImageList
         private void OnTreeViewItemDoubleClick(object sender, RoutedEventArgs e)
         {
             BitmapImage bitmapImage = this.SelectedItemImage;
-            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
-            ImageViewControl imageViewControl = mainWindow.GetImageViewControl();
-            imageViewControl.SetImageSource(bitmapImage);
+            if(bitmapImage != null)
+            {
+                MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+                // set imageview
+                ImageViewControl imageViewControl = mainWindow.GetImageViewControl();
+                imageViewControl.SetImageSource(bitmapImage);
+            }
         }
 
         // Add Button Handler

--- a/Module/ImageView/ImageViewControl.xaml
+++ b/Module/ImageView/ImageViewControl.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <GroupBox x:Name="groupBox" Header="이미지 뷰어" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-        <Canvas x:Name="imageCanvas" MouseDown="imageCanvas_MouseDown" MouseMove="imageCanvas_MouseMove">
+        <Canvas x:Name="imageCanvas" MouseDown="ImageCanvas_MouseDown" MouseMove="ImageCanvas_MouseMove">
             <Image x:Name="bgImage" Width="{Binding Path=ActualWidth, ElementName=imageCanvas}" Height="{Binding Path=ActualHeight, ElementName=imageCanvas}" Stretch="Uniform"></Image>
         </Canvas>
     </GroupBox>

--- a/Module/ImageView/ImageViewControl.xaml.cs
+++ b/Module/ImageView/ImageViewControl.xaml.cs
@@ -26,7 +26,10 @@ namespace ExtremeEnviroment.Module.ImageView
             InitializeComponent();
             InitControl();
         }
-
+        public void SetImageSource(BitmapImage bitmapImage)
+        {
+            this.bgImage.Source = bitmapImage;
+        }
         private void InitControl()
         {
             // load imagesource
@@ -37,7 +40,7 @@ namespace ExtremeEnviroment.Module.ImageView
             this.bgImage.Source = bitmapImage;
         }
 
-        private void imageCanvas_MouseDown(object sender, MouseButtonEventArgs e)
+        private void ImageCanvas_MouseDown(object sender, MouseButtonEventArgs e)
         {
             if(e.LeftButton == MouseButtonState.Pressed)
             {
@@ -55,7 +58,7 @@ namespace ExtremeEnviroment.Module.ImageView
             }
         }
 
-        private void imageCanvas_MouseMove(object sender, MouseEventArgs e)
+        private void ImageCanvas_MouseMove(object sender, MouseEventArgs e)
         {
             if(e.LeftButton == MouseButtonState.Pressed)
             {

--- a/Module/ImageView/ImageViewControl.xaml.cs
+++ b/Module/ImageView/ImageViewControl.xaml.cs
@@ -24,19 +24,9 @@ namespace ExtremeEnviroment.Module.ImageView
         public ImageViewControl()
         {
             InitializeComponent();
-            InitControl();
         }
         public void SetImageSource(BitmapImage bitmapImage)
         {
-            this.bgImage.Source = bitmapImage;
-        }
-        private void InitControl()
-        {
-            // load imagesource
-            BitmapImage bitmapImage = new BitmapImage();
-            bitmapImage.BeginInit();
-            bitmapImage.UriSource = new Uri("pack://application:,,/Resources/sample_image.jpg");
-            bitmapImage.EndInit();
             this.bgImage.Source = bitmapImage;
         }
 


### PR DESCRIPTION
이미지 아이템을 더블클릭하면 이미지 뷰어 화면에서 확인할 수 있음.

추후 metadata 속성창으로 데이터 전송시에도 double click 이벤트 함수쪽에 구현하면 됨.

resolve #6 