### PR TITLE
수정 이미지 삭제 후 추가 했을 때 정상 동작함

### DIFF
--- a/Module/ImageList/ImageListControl.xaml.cs
+++ b/Module/ImageList/ImageListControl.xaml.cs
@@ -301,10 +301,13 @@ namespace ExtremeEnviroment.Module.ImageList
         // Remove Button Handler
         private void BtnRemoveItem_Click(object sender, RoutedEventArgs e)
         {
-            if (this.ImageTree.SelectedItem != null)
+            if (this.SelectedImageData != null)
             {
-                this.ImageTree.Items.Remove(this.ImageTree.SelectedItem);
+                ImageData selectedImageData = this.SelectedImageData;
+                this.ImageTree.Items.Remove(selectedImageData.ImageTreeViewItem);
+                this.imageDataList.Remove(selectedImageData);
                 // TODO: 삭제되는 아이템이랑 연결된 컨트롤도 초기화 필요
+                this.RefreshRelativeControls();
             }
         }
 


### PR DESCRIPTION
이미지를 삭제하고 난 이후에 추가 했을때 삭제 했던 아이템이 다시 화면에 노출되는 문제가 발생하였음.

TreeItem 에서만 삭제 하고 실제 DataList 에서는 삭제하지 않아서 발생한 문제.

DataList에서도 선택된 아이템을 삭제하도록 수정함.